### PR TITLE
Bootstrap 4 validation

### DIFF
--- a/inst/assets/shinyvalidate.js
+++ b/inst/assets/shinyvalidate.js
@@ -95,9 +95,49 @@ const bs3Strategy = {
     return true;
   }
 };
-strategies.push(bs3Strategy);
 
-// TODO: Support Bootstrap 4 too
+// https://getbootstrap.com/docs/4.4/components/forms/#server-side
+const bs4Strategy = {
+  findInputControl: function(el) {
+    el = $(el);
+    const inputControl = el.is(".form-control") ? el : el.find(".form-control");
+    return inputControl.length === 0 ? null : inputControl;
+  },
+  setInvalid: function(el, binding, id, message) {
+    const inputControl = this.findInputControl(el);
+    if (!inputControl) {
+      return false;
+    }
+    inputControl.addClass("is-invalid");
+    inputControl.siblings(".shiny-validation-message").remove();
+    if (message) {
+      const msgDiv = $(document.createElement("span")).
+        addClass(["invalid-feedback", "shiny-validation-message"]).
+        text(message);
+      inputControl.after(msgDiv);
+    }
+    return true;
+  },
+  clearInvalid: function(el, binding, id) {
+    const inputControl = this.findInputControl(el);
+    if (!inputControl) {
+      return false;
+    }
+    inputControl.removeClass("is-invalid");
+    inputControl.siblings(".shiny-validation-message").remove();
+    return true;
+  }
+};
+
+if (window.jQuery) {
+  const bsVersion = window.jQuery.fn.tab.Constructor.VERSION;
+  if (bsVersion.match(/^3\./)) {
+    strategies.push(bs3Strategy);
+  } else {
+    // Assuming this strategy will work for BS5 and beyond
+    strategies.push(bs4Strategy);
+  }
+}
 
 function setInvalid(el, binding, id, message = null) {
   for (var i = 0; i < strategies.length; i++) {

--- a/inst/assets/shinyvalidate.js
+++ b/inst/assets/shinyvalidate.js
@@ -92,10 +92,10 @@ const bsStrategy = {
       // we fallback to putting is-invalid on the container, which should be compatible 
       // with Selectize + BS4 https://github.com/rstudio/shiny/blob/2bd158a4/inst/www/shared/selectize/scss/selectize.bootstrap4.scss#L131-L140
       const control = inputContainer.find(".form-control");
-      if (!control.length) {
-        inputContainer.addClass("is-invalid");
-      } else {
+      if (control.length) {
         control.addClass("is-invalid");
+      } else {
+        inputContainer.addClass("is-invalid");
       }
     }
     
@@ -121,10 +121,10 @@ const bsStrategy = {
       inputContainer.removeClass("has-error");
     } else {
       const control = inputContainer.find(".form-control");
-      if (!control.length) {
-        inputContainer.removeClass("is-invalid");
-      } else {
+      if (control.length) {
         control.removeClass("is-invalid");
+      } else {
+        inputContainer.removeClass("is-invalid");
       }
     }
     

--- a/inst/assets/shinyvalidate.js
+++ b/inst/assets/shinyvalidate.js
@@ -73,7 +73,7 @@ const bsStrategy = {
   },
   findInputContainer: function(el) {
     el = $(el);
-    const inputContainer = el.is(".shiny-input-container") ? el : el.parents(".shiny-input-container");
+    const inputContainer = el.is(".form-group") ? el : el.parents(".form-group");
     return inputContainer.length === 0 ? null : inputContainer;
   },
   setInvalid: function(el, binding, id, message) {

--- a/inst/assets/shinyvalidate.js
+++ b/inst/assets/shinyvalidate.js
@@ -91,7 +91,7 @@ const bsStrategy = {
       // (it conflicts with selectize CSS), so in the event that it's missing , 
       // we fallback to putting is-invalid on the container, which should be compatible 
       // with Selectize + BS4 https://github.com/rstudio/shiny/blob/2bd158a4/inst/www/shared/selectize/scss/selectize.bootstrap4.scss#L131-L140
-      const control = inputContainer.find(".form-control").first();
+      const control = inputContainer.find(".form-control");
       if (!control.length) {
         inputContainer.addClass("is-invalid");
       } else {
@@ -120,7 +120,7 @@ const bsStrategy = {
     if (this.isBS3()) {
       inputContainer.removeClass("has-error");
     } else {
-      const control = inputContainer.find(".form-control").first();
+      const control = inputContainer.find(".form-control");
       if (!control.length) {
         inputContainer.removeClass("is-invalid");
       } else {


### PR DESCRIPTION
Adds Bootstrap 4 support for the ["It Just Works" approach to input validation](https://rstudio.github.io/shinyvalidate/articles/displaying.html#it-just-works-built-in-support-for-bootstrap-3) (that pkgdown section will need an update after this lands).

## Testing notes

Install `remotes::install_github("rstudio/shinyvalidate")` and `remotes::install_github("rstudio/shiny#2950")`. Verify that orange feedback appears on initial load for all the input widgets. Also, verify that entering a suitable value removes the feedback. After verifying that this works for BS4 (i.e., `bs_theme_new()`) verify that it also works for BS3 (i.e., `bs_theme_new(3)`)

```r
library(shiny)
library(shinyvalidate)
library(bootstraplib)
shinyOptions(bootstraplib = TRUE)
bs_theme_new()
bs_theme_accent_colors(danger = "orange")

ui <- fluidPage(
  textInput("text", ""),
  selectInput("select", "", multiple = TRUE, state.name),
  fileInput("file", ""),
  dateInput("date", ""),
  dateRangeInput("dateRange", ""),
  sliderInput("slider", "", min = 0, max = 100, value = 50, step = 1),
  checkboxInput("checkbox", "", value = FALSE),
  checkboxGroupInput("checkboxGroup", "", choices = c("A", "B")),
  radioButtons("radio", "", choices = c("A", "B"))
)

server <- function(input, output, session) {
  iv <- InputValidator$new()
  iv$add_rule("text", sv_required("Enter some text"))
  iv$add_rule("select", sv_required("Choose a state"))
  iv$add_rule("file", sv_required("Please choose a file"))
  iv$add_rule("date", ~if (. <= Sys.Date()) "Choose a future date!")
  iv$add_rule("dateRange", ~if (min(.) <= Sys.Date()) "Choose future dates!")
  iv$add_rule("slider", ~if (. %% 2 == 0) "Choose an odd number!")
  iv$add_rule("checkbox", ~if (!.) "Please check true!")
  iv$add_rule("checkboxGroup", ~if (!identical(., "B")) "Please check (just) B!")
  iv$add_rule("radio", ~if (!identical(., "B")) "Please check B!")
  iv$enable()
}

shinyApp(ui, server)

```