### PR TITLE
Improve shinyvalidate.js

### DIFF
--- a/R/validator.R
+++ b/R/validator.R
@@ -276,7 +276,7 @@ InputValidator <- R6::R6Class("InputValidator", cloneable = FALSE,
               results <<- c(results, stats::setNames(list(NULL), fullname))
             }
           } else {
-            results[[fullname]] <<- result
+            results[[fullname]] <<- list(type = "error", message = result)
           }
         })
       })

--- a/inst/examples/03_custom_inputs/www/camera_input.js
+++ b/inst/examples/03_custom_inputs/www/camera_input.js
@@ -41,9 +41,9 @@ if (window.Shiny) {
     
     // The following two methods, setInvalid and clearInvalid, will be called
     // whenever this input fails or passes (respectively) validation.
-    setInvalid: function(el, message) {
+    setInvalid: function(el, data) {
       el.classList.add("invalid");
-      el.querySelector(".feedback-message").innerText = message;
+      el.querySelector(".feedback-message").innerText = data.message;
     },
     clearInvalid: function(el) {
       el.classList.remove("invalid");

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -41,9 +41,9 @@ test_that("InputValidator add_rule()", {
       expect_false(iv$is_valid())
       
       expect_identical(iv$validate(), rlang::list2(
-        !!session$ns("inputA") := "Input A is required",
-        !!session$ns("inputB") := "Input B is required",
-        !!session$ns("inputC") := "Input C is required"
+        !!session$ns("inputA") := list(type = "error", message = "Input A is required"),
+        !!session$ns("inputB") := list(type = "error", message = "Input B is required"),
+        !!session$ns("inputC") := list(type = "error", message = "Input C is required")
       ))
     })
     
@@ -53,8 +53,8 @@ test_that("InputValidator add_rule()", {
     shiny::isolate({
       expect_false(iv$is_valid())
       expect_identical(iv$validate(), rlang::list2(
-        !!session$ns("inputA") := "Input A is required",
-        !!session$ns("inputC") := "Input C is required",
+        !!session$ns("inputA") := list(type = "error", message = "Input A is required"),
+        !!session$ns("inputC") := list(type = "error", message = "Input C is required"),
         !!session$ns("inputB") := NULL
       ))
     })
@@ -86,14 +86,14 @@ test_that("InputValidator add_rule() stops on first failing rule", {
       for (x in list(NULL, FALSE, "whatever")) {
         session$setInputs(a = x)
         expect_identical(iv$validate(), rlang::list2(
-          !!session$ns("a") := "rule 1"
+          !!session$ns("a") := list(type = "error", message = "rule 1")
         ))
       }
       
       session$setInputs(a = TRUE)
       
       expect_identical(iv$validate(), rlang::list2(
-        !!session$ns("a") := "rule 2"
+        !!session$ns("a") := list(type = "error", message = "rule 2")
       ))
     })
   })

--- a/vignettes/displaying.Rmd
+++ b/vignettes/displaying.Rmd
@@ -70,11 +70,11 @@ At the time of this writing, the Shiny team is in the midst of a large project t
 
 Custom input widgets that don't depend on Bootstrap can define their own behavior for displaying validation errors, by implementing two new methods on their JavaScript [`InputBinding` objects](https://shiny.rstudio.com/articles/building-inputs.html#write-an-input-binding).
 
--   `binding.setInvalid(el, message)` will be called when a validation error should be displayed. The `message` will be a non-empty string. Besides the message being displayed, other CSS adjustments should be made to make it clear that the input is invalid (having the control label and border colors turn red, or background color turning pink, for example).
+-   `binding.setInvalid(el, data)` will be called when a validation error should be displayed. The `data` object has two fields: `data.type` is currently always `"error"` (in the future we may add `"warning"` and `"info"` types), and `data.message` will be a non-empty string specifying the message to display. Besides displaying the message, other UI changes/CSS adjustments should be made to make it clear that the input is invalid (having the control label and border colors turn red, or background color turning pink, for example).
 
 -   `binding.clearInvalid(el)` will be called when a validation error is no longer appropriate to be displayed. Any previously added validation message should be removed, and any CSS adjustments (like the aforementioned red labels and borders) should be reversed.
 
-Note that shinyvalidate will invoke `setInvalid` and `clearInvalid` in seemingly random order. It may repeatedly call `clearInvalid` on an input without intervening `setInvalid` calls. It may call `setInvalid` multiple times in a row with the same `message`. Therefore, both `setInvalid` and `clearInvalid` must be prepared to deal with inputs in "normal" or "error" states.
+Note that shinyvalidate will invoke `setInvalid` and `clearInvalid` in seemingly random order. It may repeatedly call `clearInvalid` on an input without intervening `setInvalid` calls. It may call `setInvalid` multiple times in a row with the same `data`. Therefore, both `setInvalid` and `clearInvalid` must be prepared to deal with inputs in "normal" or "error" states.
 
 Example 03_custom_inputs [[source](https://github.com/rstudio/shinyvalidate/tree/master/inst/examples/03_custom_inputs), live demo TODO] uses a custom input widget to implement a webcam capture input, and uses `setInvalid`/`clearInvalid` methods to overlay the validation message on top of the image preview:
 
@@ -91,6 +91,7 @@ $(document).on("shinyvalidate:show", function(event) {
   let el = event.el;
   let binding = event.binding;
   let id = event.id;
+  let type = event.type; // always "error"
   let message = event.message;
   event.preventDefault();
   
@@ -114,6 +115,8 @@ The following properties are available on the `event` object:
 -   `binding` - The Shiny `InputBinding` object.
 
 -   `id` - A string indicating the input ID.
+
+-   `type` - Currently hardcoded to `"error"`. (In the future, we may introduce other types like `"warning"` and `"info"`.)
 
 -   `message` - A textual string (not HTML) indicating the message to be displayed.
 


### PR DESCRIPTION
This change future-proofs the JavaScript API by turning simple `message` strings into `{type: "error", message: "..."}` objects. This makes it easier for us to add capabilities in the future, such as additional types (warn, info) or properties (icon, color).