### PR TITLE
Fix compatibility with shinytest

### DIFF
--- a/inst/assets/shinyvalidate.js
+++ b/inst/assets/shinyvalidate.js
@@ -4,8 +4,8 @@
  * for that id. Instead, we use several strategies that we try in turn; once
  * a strategy succeeds, we stop.
  */
- 
- const strategies = [];
+
+var strategies = [];
 
 /**
  * This strategy depends on jQuery event handlers. Event handlers
@@ -13,27 +13,33 @@
  * or evt.stopImmediatePropagation() to signal that they have handled
  * the showing/clearing.
  */
-const eventStrategy = {
-  setInvalid: function(el, binding, id, data) {
-    const e = $.Event("shinyvalidate:show", $.extend({
+var eventStrategy = {
+  setInvalid: function (el, binding, id, data) {
+    var e = $.Event(
+      "shinyvalidate:show",
+      $.extend(
+        {
+          el: el,
+          binding: binding,
+          id: id,
+        },
+        data
+      )
+    );
+    $(el).trigger(e);
+
+    return e.isDefaultPrevented();
+  },
+  clearInvalid: function (el, binding, id) {
+    var e = $.Event("shinyvalidate:clear", {
       el: el,
       binding: binding,
       id: id,
-    }, data));
-    $(el).trigger(e);
-    
-    return e.isDefaultPrevented();
-  },
-  clearInvalid: function(el, binding, id) {
-    const e = $.Event("shinyvalidate:clear", {
-      el: el,
-      binding: binding,
-      id: id
     });
     $(el).trigger(e);
-    
+
     return e.isDefaultPrevented();
-  }
+  },
 };
 strategies.push(eventStrategy);
 
@@ -41,21 +47,21 @@ strategies.push(eventStrategy);
  * This strategy depends on the input binding itself implementing methods for
  * setInvalid/clearInvalid.
  */
-const bindingStrategy = {
-  setInvalid: function(el, binding, id, data) {
-    if (typeof(binding.setInvalid) !== "function") {
+var bindingStrategy = {
+  setInvalid: function (el, binding, id, data) {
+    if (typeof binding.setInvalid !== "function") {
       return false;
     }
     binding.setInvalid(el, data);
     return true;
   },
-  clearInvalid: function(el, binding, id) {
-    if (typeof(binding.clearInvalid) !== "function") {
+  clearInvalid: function (el, binding, id) {
+    if (typeof binding.clearInvalid !== "function") {
       return false;
     }
     binding.clearInvalid(el);
     return true;
-  }
+  },
 };
 strategies.push(bindingStrategy);
 
@@ -63,23 +69,23 @@ strategies.push(bindingStrategy);
  * This strategy detects .shiny-input-container at or above the el, and uses
  * Bootstrap 3 & 4 classes to display validation messages.
  */
-const bsStrategy = {
-  isBS3: function() {
+var bsStrategy = {
+  isBS3: function () {
     if (!$.fn.tooltip) {
       return false;
     }
     return $.fn.tooltip.Constructor.VERSION.match(/^3\./);
   },
-  findInputContainer: function(el) {
+  findInputContainer: function (el) {
     el = $(el);
-    const inputContainer = el.is(".form-group") ? el : el.parents(".form-group");
+    var inputContainer = el.is(".form-group") ? el : el.parents(".form-group");
     return inputContainer.length === 0 ? null : inputContainer;
   },
-  setInvalid: function(el, binding, id, data) {
+  setInvalid: function (el, binding, id, data) {
     if (data.type !== "error") {
       return false;
     }
-    const inputContainer = this.findInputContainer(el);
+    var inputContainer = this.findInputContainer(el);
     if (!inputContainer) {
       return false;
     }
@@ -87,62 +93,72 @@ const bsStrategy = {
       inputContainer.addClass("has-error");
     } else {
       // BS4 wants .is-invalid on a .form-control (e.g., <input class="form-control">)
-      // *and* wants it to be a _sibling_ of .invalid-message in order to be displayed. 
+      // *and* wants it to be a _sibling_ of .invalid-message in order to be displayed.
       //
-      // Unfortunately, we can't always assume that .form-control exists 
-      // (it conflicts with selectize CSS), so in the event that it's missing , 
-      // we fallback to putting is-invalid on the container, which should be compatible 
+      // Unfortunately, we can't always assume that .form-control exists
+      // (it conflicts with selectize CSS), so in the event that it's missing ,
+      // we fallback to putting is-invalid on the container, which should be compatible
       // with Selectize + BS4 https://github.com/rstudio/shiny/blob/2bd158a4/inst/www/shared/selectize/scss/selectize.bootstrap4.scss#L131-L140
-      const control = inputContainer.find(".form-control");
+      var control = inputContainer.find(".form-control");
       if (control.length) {
         control.addClass("is-invalid");
       } else {
         inputContainer.addClass("is-invalid");
       }
     }
-    
+
     inputContainer.children(".shiny-validation-message").remove();
     if (data.message) {
-      const feedbackClass = this.isBS3() ? "help-block" : "invalid-feedback";
-      const msg = $(document.createElement("span")).
-        addClass([feedbackClass, "shiny-validation-message"]).
-        text(data.message);
-      // Yes, this is a terrible hack to get feedback to display when 
+      var feedbackClass = this.isBS3() ? "help-block" : "invalid-feedback";
+      var msg = $(document.createElement("span"))
+        .addClass([feedbackClass, "shiny-validation-message"])
+        .text(data.message);
+      // Yes, this is a terrible hack to get feedback to display when
       // there is no .form-control in BS4
-      msg.attr('style', function(i, s) { return (s || '') + 'display: block !important;' });
+      msg.attr("style", function (i, s) {
+        return (s || "") + "display: block !important;";
+      });
       inputContainer.append(msg);
     }
     return true;
   },
-  clearInvalid: function(el, binding, id) {
-    const inputContainer = this.findInputContainer(el);
+  clearInvalid: function (el, binding, id) {
+    var inputContainer = this.findInputContainer(el);
     if (!inputContainer) {
       return false;
     }
     if (this.isBS3()) {
       inputContainer.removeClass("has-error");
     } else {
-      const control = inputContainer.find(".form-control");
+      var control = inputContainer.find(".form-control");
       if (control.length) {
         control.removeClass("is-invalid");
       } else {
         inputContainer.removeClass("is-invalid");
       }
     }
-    
+
     inputContainer.children(".shiny-validation-message").remove();
     return true;
-  }
+  },
 };
 strategies.push(bsStrategy);
 
-function setInvalid(el, binding, id, data = null) {
+function setInvalid(el, binding, id, data) {
+  if (data === void 0) {
+    data = null;
+  }
   for (var i = 0; i < strategies.length; i++) {
     if (strategies[i].setInvalid(el, binding, id, data)) {
       return;
     }
   }
-  console.warn("Don't know how to display input validation feedback for input '" + id + "'. The message was:\n" + JSON.stringify(data));
+  console.warn(
+    "Don't know how to display input validation feedback for input '" +
+      id +
+      "'. The message was:\n" +
+      JSON.stringify(data)
+  );
 }
 
 function clearInvalid(el, binding, id) {
@@ -151,31 +167,39 @@ function clearInvalid(el, binding, id) {
       return;
     }
   }
-  console.warn("Don't know how to clear input validation feedback for input '" + id + "'");
+  console.warn(
+    "Don't know how to clear input validation feedback for input '" + id + "'"
+  );
 }
 
 function getBoundInputsMap() {
-  const results = new Map();
-  $(".shiny-bound-input").each(function(index, el) {
-    const binding = $(el).data("shiny-input-binding");
+  var results = {};
+  $(".shiny-bound-input").each(function (index, el) {
+    var binding = $(el).data("shiny-input-binding");
     if (binding) {
-      const id = binding.getId(el);
-      results.set(id, {id: id, el: el, binding: binding});
+      var id = binding.getId(el);
+      results[id] = { id: id, el: el, binding: binding };
     }
   });
   return results;
 }
 
 if (window.Shiny) {
-  Shiny.addCustomMessageHandler("validation-jcheng5", function(message) {
-    const boundInputsMap = getBoundInputsMap();
-    for (const [key, value] of Object.entries(message)) {
-      const input = boundInputsMap.get(key);
+  Shiny.addCustomMessageHandler("validation-jcheng5", function (message) {
+    var boundInputsMap = getBoundInputsMap();
+
+    for (var key in message) {
+      var value = message[key];
+      var input = boundInputsMap[key];
       if (!input) {
-        console.warn("Couldn't perform validation update on input with id '" + key + "': input not found");
+        console.warn(
+          "Couldn't perform validation update on input with id '" +
+            key +
+            "': input not found"
+        );
         continue;
       }
-      
+
       if (value === null) {
         clearInvalid(input.el, input.binding, input.id);
       } else {


### PR DESCRIPTION
When trying to test `shinyvalidate` with `shinytest` no error messages would show up at all. This was because there were some ES6 features used in `shinyvalidate.js` that are not supported in selenium. 

This PR just replaces the `consts` with `var` and converts the `boundInputMap` to a standard object instead of a `Map`. 

All the tests pass and now shinytest can see validation messages. 

As a side note, I accidentally prettified the code. If it messes with the preferred JS formatting let me know and I will fix it. 