### PR TITLE
Remove install of dev `promises` pkg

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -65,7 +65,6 @@ jobs:
         run: |
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
-          remotes::install_github("rstudio/promises") # Can remove when shiny goes to CRAN
         shell: Rscript {0}
 
       - name: Check


### PR DESCRIPTION
Since shiny v1.6 is available, the installation of `promises` from GitHub is no longer required.