### PR TITLE
Increment version to dev version (`v0.1.1.9000`)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyvalidate
 Title: Input Validation for Shiny Apps
-Version: 0.1.1
+Version: 0.1.1.9000
 Authors@R: c(
     person("Richard", "Iannone", , "rich@rstudio.com", c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3925-190X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# shinyvalidate (development version)
+
 # shinyvalidate 0.1.1
 
 * Fix an incompatibility between jQueryUI and shinyvalidate. (#32)


### PR DESCRIPTION
This PR updates the version of the package to the next development version (`v0.1.1.9000`). This also modifies the `NEWS.md` file such that a new section has been created for the development version. This was done by using the `usethis::use_dev_version()` function.

Fixes: https://github.com/rstudio/shinyvalidate/issues/43