### PR TITLE
Allow for HTML like return values that can be converted to single character values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyvalidate
 Title: Input Validation for Shiny Apps
-Version: 0.1.1.9000
+Version: 0.1.1.9001
 Authors@R: c(
     person("Richard", "Iannone", , "rich@rstudio.com", c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3925-190X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinyvalidate (development version)
 
+* Support HTML messages when failing a validation. (#55)
+
 # shinyvalidate 0.1.1
 
 * Fix an incompatibility between jQueryUI and shinyvalidate. (#32)

--- a/R/validator.R
+++ b/R/validator.R
@@ -163,10 +163,10 @@ InputValidator <- R6::R6Class("InputValidator", cloneable = FALSE,
     #'   `session$ns("x")`.)
     #' @param rule A function that takes (at least) one argument: the input's
     #'   value. The function should return `NULL` if it passes validation, and
-    #'   if not, a single-element character vector containing an error message
-    #'   to display to the user near the input. You can alternatively provide a
-    #'   single-sided formula instead of a function, using `.` as the variable
-    #'   name for the input value being validated.
+    #'   if not, a single-element character vector or HTML tag containing an
+    #'   error message to display to the user near the input. You can
+    #'   alternatively provide a single-sided formula instead of a function,
+    #'   using `.` as the variable name for the input value being validated.
     #' @param ... Optional: Additional arguments to pass to the `rule` function
     #'   whenever it is invoked.
     #' @param session. The session object to which the input belongs. (There's
@@ -324,6 +324,11 @@ InputValidator <- R6::R6Class("InputValidator", cloneable = FALSE,
             }
           }
         )
+        result_is_html <- FALSE
+        if (any(class(result) %in% c("shiny.tag", "shiny.tag.list", "shiny.tag.function", "html"))) {
+          result <- as.character(result)
+          result_is_html <- TRUE
+        }
         # Validation rules are required to return one of the following:
         # * NULL: the value has passed the validation rule
         # * character(1): the rule didn't pass validation
@@ -350,7 +355,7 @@ InputValidator <- R6::R6Class("InputValidator", cloneable = FALSE,
           results[[fullname]] <<- TRUE
         } else {
           console_log("  ...Failed")
-          results[[fullname]] <<- list(type = "error", message = result)
+          results[[fullname]] <<- list(type = "error", message = result, is_html = result_is_html)
         }
       })
       # Change all TRUE entries to NULL. We have to use list(NULL) instead of

--- a/inst/assets/shinyvalidate.js
+++ b/inst/assets/shinyvalidate.js
@@ -3373,7 +3373,8 @@
       inputContainer.children(".shiny-validation-message").remove();
       if (data.message) {
         var feedbackClass = this.isBS3() ? "help-block" : "invalid-feedback";
-        var msg = $(document.createElement("span")).addClass([feedbackClass, "shiny-validation-message"]).text(data.message);
+        var method = data.is_html ? "html" : "text";
+        var msg = $(document.createElement("span")).addClass([feedbackClass, "shiny-validation-message"])[method](data.message);
         msg.attr("style", function(i, s) {
           return (s || "") + "display: block !important;";
         });

--- a/man/InputValidator.Rd
+++ b/man/InputValidator.Rd
@@ -175,10 +175,10 @@ qualified by a module namespace; e.g. pass \code{"x"} and not
 
 \item{\code{rule}}{A function that takes (at least) one argument: the input's
 value. The function should return \code{NULL} if it passes validation, and
-if not, a single-element character vector containing an error message
-to display to the user near the input. You can alternatively provide a
-single-sided formula instead of a function, using \code{.} as the variable
-name for the input value being validated.}
+if not, a single-element character vector or HTML tag containing an
+error message to display to the user near the input. You can
+alternatively provide a single-sided formula instead of a function,
+using \code{.} as the variable name for the input value being validated.}
 
 \item{\code{...}}{Optional: Additional arguments to pass to the \code{rule} function
 whenever it is invoked.}

--- a/srcjs/shinyvalidate.js
+++ b/srcjs/shinyvalidate.js
@@ -104,10 +104,11 @@ const bsStrategy = {
     inputContainer.children(".shiny-validation-message").remove();
     if (data.message) {
       const feedbackClass = this.isBS3() ? "help-block" : "invalid-feedback";
+      const method = data.is_html ? "html" : "text";
       const msg = $(document.createElement("span")).
-        addClass([feedbackClass, "shiny-validation-message"]).
-        text(data.message);
-      // Yes, this is a terrible hack to get feedback to display when 
+        addClass([feedbackClass, "shiny-validation-message"])
+        [method](data.message);
+      // Yes, this is a terrible hack to get feedback to display when
       // there is no .form-control in BS4
       msg.attr('style', function(i, s) { return (s || '') + 'display: block !important;' });
       inputContainer.append(msg);

--- a/tests/testthat/_snaps/validator.md
+++ b/tests/testthat/_snaps/validator.md
@@ -7,6 +7,9 @@
     $`mock-session-a`$message
     [1] "An unexpected error occurred during input validation: normal error"
     
+    $`mock-session-a`$is_html
+    [1] FALSE
+    
     
     $`mock-session-b`
     $`mock-session-b`$type
@@ -15,6 +18,9 @@
     $`mock-session-b`$message
     [1] "An unexpected error occurred during input validation: safe error"
     
+    $`mock-session-b`$is_html
+    [1] FALSE
+    
     
     $`mock-session-c`
     $`mock-session-c`$type
@@ -22,6 +28,9 @@
     
     $`mock-session-c`$message
     [1] "An unexpected error occurred during input validation"
+    
+    $`mock-session-c`$is_html
+    [1] FALSE
     
     
 
@@ -34,6 +43,9 @@
     $`mock-session-a`$message
     [1] "An unexpected error occurred during input validation"
     
+    $`mock-session-a`$is_html
+    [1] FALSE
+    
     
     $`mock-session-b`
     $`mock-session-b`$type
@@ -42,6 +54,9 @@
     $`mock-session-b`$message
     [1] "An unexpected error occurred during input validation: safe error"
     
+    $`mock-session-b`$is_html
+    [1] FALSE
+    
     
     $`mock-session-c`
     $`mock-session-c`$type
@@ -49,6 +64,9 @@
     
     $`mock-session-c`$message
     [1] "An unexpected error occurred during input validation"
+    
+    $`mock-session-c`$is_html
+    [1] FALSE
     
     
 

--- a/tests/testthat/test-rules.R
+++ b/tests/testthat/test-rules.R
@@ -11,13 +11,13 @@ test_that("`sv_optional()` basic use cases", {
       expect_true(iv$is_valid())
       expect_identical(iv$validate(), rlang::list2(!!session$ns("x") := NULL))
     })
-    
+
     session$setInputs(x = TRUE)
     shiny::isolate({
       expect_false(iv$is_valid())
       expect_identical(
         iv$validate(),
-        rlang::list2(!!session$ns("x") := list(type = "error", message = "failure"))
+        rlang::list2(!!session$ns("x") := list(type = "error", message = "failure", is_html = FALSE))
       )
     })
   })
@@ -55,12 +55,12 @@ test_that("compose_rules different input types", {
       NULL
     }
   )(input)
-  
+
   expect_error(compose_rules("not a function"))
 })
 
 expect_sv_fail <- function(rule, ...) {
-  
+
   lapply(
     rlang::list2(...),
     FUN = function(x) {
@@ -70,7 +70,7 @@ expect_sv_fail <- function(rule, ...) {
 }
 
 expect_sv_pass <- function(rule, ...) {
-  
+
   lapply(
     rlang::list2(...),
     FUN = function(x) {
@@ -80,7 +80,7 @@ expect_sv_pass <- function(rule, ...) {
 }
 
 test_that("the `sv_lt()` rule function works properly", {
-  
+
   always_pass <- list(-1, 0, 0L)
   always_fail <- list(1, 2, 2L, c(-1, 2), Inf)
   pass_if_multiple <- list(c(-10:-1))
@@ -88,34 +88,34 @@ test_that("the `sv_lt()` rule function works properly", {
   pass_if_multiple_na <- list(c(-2, -1, NA), c(NA, NA, NA))
   pass_if_nan <- list(NaN)
   pass_if_inf <- list(-Inf)
-  
+
   rule <- sv_lt(rhs = 1)
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_lt(rhs = 1, allow_multiple = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_lt(rhs = 1, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_lt(rhs = 1, allow_nan = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_nan)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_lt(rhs = 1, allow_multiple = TRUE, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_nan, !!!pass_if_inf)
-  
+
   rule <- sv_lt(rhs = 1, allow_inf = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_inf)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na)
 })
 
 test_that("the `sv_lte()` rule function works properly", {
-  
+
   always_pass <- list(-1, 0, 1, 1L)
   always_fail <- list(2, 2L, c(-1, 2), Inf)
   pass_if_multiple <- list(-10:1, c(-3, -5.2, 0.9))
@@ -123,34 +123,34 @@ test_that("the `sv_lte()` rule function works properly", {
   pass_if_multiple_na <- list(c(-2, -1, NA), c(NA, NA, NA))
   pass_if_nan <- list(NaN)
   pass_if_inf <- list(-Inf)
-  
+
   rule <- sv_lte(rhs = 1)
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_lte(rhs = 1, allow_multiple = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_lte(rhs = 1, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_lte(rhs = 1, allow_nan = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_nan)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_lte(rhs = 1, allow_multiple = TRUE, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_nan, !!!pass_if_inf)
-  
+
   rule <- sv_lte(rhs = 1, allow_inf = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_inf)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na)
 })
 
 test_that("the `sv_gte()` rule function works properly", {
-  
+
   always_pass <- list(1, 2, 3, 3L)
   always_fail <- list(-2, -2L, -1, 0, c(-1, 2), -Inf)
   pass_if_multiple <- list(1:10, c(3, 5.2, 1.0))
@@ -158,34 +158,34 @@ test_that("the `sv_gte()` rule function works properly", {
   pass_if_multiple_na <- list(c(1, 2, NA), c(NA, NA, NA))
   pass_if_nan <- list(NaN)
   pass_if_inf <- list(Inf)
-  
+
   rule <- sv_gte(rhs = 1)
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_gte(rhs = 1, allow_multiple = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_gte(rhs = 1, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_gte(rhs = 1, allow_nan = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_nan)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_gte(rhs = 1, allow_multiple = TRUE, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_nan, !!!pass_if_inf)
-  
+
   rule <- sv_gte(rhs = 1, allow_inf = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_inf)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na)
 })
 
 test_that("the `sv_gt()` rule function works properly", {
-  
+
   always_pass <- list(2, 3, 3L)
   always_fail <- list(-2, -2L, -1, 0, c(-1, 2), -Inf)
   pass_if_multiple <- list(2:10, c(3, 5.2, 1.1))
@@ -193,34 +193,34 @@ test_that("the `sv_gt()` rule function works properly", {
   pass_if_multiple_na <- list(c(2, 3, NA), c(NA, NA, NA))
   pass_if_nan <- list(NaN)
   pass_if_inf <- list(Inf)
-  
+
   rule <- sv_gt(rhs = 1)
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_gt(rhs = 1, allow_multiple = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_gt(rhs = 1, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_gt(rhs = 1, allow_nan = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_nan)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na, !!!pass_if_inf)
-  
+
   rule <- sv_gt(rhs = 1, allow_multiple = TRUE, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_nan, !!!pass_if_inf)
-  
+
   rule <- sv_gt(rhs = 1, allow_inf = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_inf)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na)
 })
 
 test_that("the `sv_equal()` rule function works properly", {
-  
+
   usually_pass <- list(1, 1L, 1.0)
   usually_fail <- list(1.1, 0.9, -1L, 2L, c(-1, 2), -Inf, Inf)
   pass_if_multiple <- list(rep(1, 10))
@@ -229,38 +229,38 @@ test_that("the `sv_equal()` rule function works properly", {
   pass_if_nan <- list(NaN)
   pass_if_inf_1 <- list(Inf)
   pass_if_inf_2 <- list(-Inf)
-  
+
   rule <- sv_equal(rhs = 1)
   expect_sv_pass(rule, !!!usually_pass)
   expect_sv_fail(rule, !!!usually_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf_1, !!!pass_if_inf_2)
-  
+
   rule <- sv_equal(rhs = 1, allow_multiple = TRUE)
   expect_sv_pass(rule, !!!usually_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!usually_fail, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf_1, !!!pass_if_inf_2)
-  
+
   rule <- sv_equal(rhs = 1, allow_na = TRUE)
   expect_sv_pass(rule, !!!usually_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!usually_fail, !!!pass_if_multiple, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf_1, !!!pass_if_inf_2)
-  
+
   rule <- sv_equal(rhs = 1, allow_nan = TRUE)
   expect_sv_pass(rule, !!!usually_pass, !!!pass_if_nan)
   expect_sv_fail(rule, !!!usually_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na, !!!pass_if_inf_1, !!!pass_if_inf_2)
-  
+
   rule <- sv_equal(rhs = 1, allow_multiple = TRUE, allow_na = TRUE)
   expect_sv_pass(rule, !!!usually_pass, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
   expect_sv_fail(rule, !!!usually_fail, !!!pass_if_nan, !!!pass_if_inf_1, !!!pass_if_inf_2)
-  
+
   rule <- sv_equal(rhs = Inf, allow_inf = TRUE)
   expect_sv_pass(rule, !!!pass_if_inf_1)
   expect_sv_fail(rule, !!!pass_if_inf_2)
-  
+
   rule <- sv_equal(rhs = Inf, allow_inf = TRUE)
   expect_sv_pass(rule, !!!pass_if_inf_1)
   expect_sv_fail(rule, !!!pass_if_inf_2)
 })
 
 test_that("the `sv_not_equal()` rule function works properly", {
-  
+
   usually_pass <- list(2, 2L, 2)
   usually_fail <- list(1, 1L, -Inf, Inf)
   pass_if_multiple <- list(rep(2, 10))
@@ -269,47 +269,47 @@ test_that("the `sv_not_equal()` rule function works properly", {
   pass_if_nan <- list(NaN)
   pass_if_inf_1 <- list(-Inf)
   pass_if_inf_2 <- list(Inf)
-  
+
   rule <- sv_not_equal(rhs = 1)
   expect_sv_pass(rule, !!!usually_pass)
   expect_sv_fail(rule, !!!usually_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf_1, !!!pass_if_inf_2)
-  
+
   rule <- sv_not_equal(rhs = 1, allow_multiple = TRUE)
   expect_sv_pass(rule, !!!usually_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!usually_fail, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf_1, !!!pass_if_inf_2)
-  
+
   rule <- sv_not_equal(rhs = 1, allow_na = TRUE)
   expect_sv_pass(rule, !!!usually_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!usually_fail, !!!pass_if_multiple, !!!pass_if_nan, !!!pass_if_multiple_na, !!!pass_if_inf_1, !!!pass_if_inf_1)
-  
+
   rule <- sv_not_equal(rhs = 1, allow_nan = TRUE)
   expect_sv_pass(rule, !!!usually_pass, !!!pass_if_nan)
   expect_sv_fail(rule, !!!usually_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na, !!!pass_if_inf_1, !!!pass_if_inf_2)
-  
+
   rule <- sv_not_equal(rhs = 1, allow_multiple = TRUE, allow_na = TRUE)
   expect_sv_pass(rule, !!!usually_pass, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
   expect_sv_fail(rule, !!!usually_fail, !!!pass_if_nan, !!!pass_if_inf_1, !!!pass_if_inf_2)
-  
+
   rule <- sv_not_equal(rhs = Inf, allow_inf = TRUE)
   expect_sv_pass(rule, !!!pass_if_inf_1)
   expect_sv_fail(rule, !!!pass_if_inf_2)
-  
+
   rule <- sv_not_equal(rhs = Inf, allow_inf = TRUE)
   expect_sv_pass(rule, !!!pass_if_inf_1)
   expect_sv_fail(rule, !!!pass_if_inf_2)
 })
 
 test_that("the `sv_between()` rule function works properly", {
-  
+
   always_pass <- list(2, 3, 4L, 9, 3:5)
   always_fail <- list(0, -1L, c(-1, 5), Inf, -Inf)
   pass_if_na <- list(NA, NA_integer_, NA_real_, c(NA, NA, NA))
   pass_if_nan <- list(NaN, c(NaN, NaN))
-  
+
   rule <- sv_between(1, 10)
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_na, !!!pass_if_nan)
-  
+
   rule <- sv_between(1, 10, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_nan)
@@ -317,7 +317,7 @@ test_that("the `sv_between()` rule function works properly", {
   rule <- sv_between(1, 10, allow_nan = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_nan)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_na)
-  
+
   expect_sv_fail(sv_between(1, 10, inclusive = c(FALSE, TRUE)), 1)
   expect_sv_fail(sv_between(1, 10, inclusive = c(TRUE, FALSE)), 10)
   expect_sv_fail(sv_between(1, 10, inclusive = c(FALSE, FALSE)), c(1, 10))
@@ -326,25 +326,25 @@ test_that("the `sv_between()` rule function works properly", {
 })
 
 test_that("the `sv_in_set()` rule function works properly", {
-  
+
   always_pass <- list(1, 2, 3, 4, 5, 5L)
-  always_fail <- 
+  always_fail <-
     list(
       0, -1L, c(-5, 0), Inf, -Inf, NA, c(NA, NA, NA), c(4, NA), c(4, 6, 4), NaN,
       "", c("", "")
     )
-  
+
   rule <- sv_in_set(1L:5L)
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail)
-  
+
   rule <- sv_in_set(as.numeric(1:5))
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail)
 })
 
 test_that("the `sv_numeric()` rule function works properly", {
-  
+
   always_pass <- list(-5E6, -1, 0, 0L, 5E6)
   always_fail <- list("text", TRUE, numeric(0), integer(0))
   pass_if_multiple <- list(c(-10:-1))
@@ -352,50 +352,50 @@ test_that("the `sv_numeric()` rule function works properly", {
   pass_if_nan <- list(NaN)
   pass_if_multiple_na <- list(c(-2, -1, NA), c(NA_real_, NA_real_), c(NA_integer_, 2))
   pass_if_inf <- list(-Inf, Inf)
-  
+
   rule <- sv_numeric()
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_inf, !!!pass_if_multiple_na)
-  
+
   rule <- sv_numeric(allow_multiple = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_inf, !!!pass_if_multiple_na)
-  
+
   rule <- sv_numeric(allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_nan, !!!pass_if_inf, !!!pass_if_multiple_na)
-  
+
   rule <- sv_numeric(allow_nan = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_nan)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_inf, !!!pass_if_multiple_na)
-  
+
   rule <- sv_numeric(allow_multiple = TRUE, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_nan, !!!pass_if_inf)
-  
+
   rule <- sv_numeric(allow_inf = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_inf)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_multiple_na)
 })
 
 test_that("the `sv_integer()` rule function works properly", {
-  
+
   always_pass <- list(-5L, -1234.0, 0L, 5E6L)
   always_fail <- list(5.6, c(NA_integer_, 2.0001), Inf, -Inf, integer(0), numeric(0))
   pass_if_multiple <- list(as.integer(-10:-1), as.numeric(3:6))
   pass_if_na <- list(NA_integer_)
   pass_if_nan <- list(NaN)
-  pass_if_multiple_na <- 
+  pass_if_multiple_na <-
     list(
       c(-2L, -1L, NA_integer_), c(NA_integer_, NA_integer_),
       c(NA_integer_, 2L), c(NA_real_, 2.0), c(NA_real_, NA_real_),
       c(NA, NA, NA)
     )
-  
+
   rule <- sv_integer()
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_na, !!!pass_if_multiple_na)
-  
+
   rule <- sv_integer(allow_multiple = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_na, !!!pass_if_na, !!!pass_if_multiple_na)
@@ -414,22 +414,22 @@ test_that("the `sv_integer()` rule function works properly", {
 })
 
 test_that("the `sv_regex()` rule function works properly", {
-  
+
   expect_null(
     sv_regex(
       pattern = "^T",
       message = "message"
     )("The shinyvalidate package.")
   )
-  
+
   expect_equal(
     sv_regex(
       pattern = "^t",
       message = "message"
-    )("The shinyvalidate package."), 
+    )("The shinyvalidate package."),
     "message"
   )
-  
+
   expect_null(
     sv_regex(
       pattern = "^t",
@@ -437,7 +437,7 @@ test_that("the `sv_regex()` rule function works properly", {
       invert = TRUE
     )("The shinyvalidate package.")
   )
-  
+
   expect_null(
     sv_regex(
       pattern = "^t",
@@ -445,7 +445,7 @@ test_that("the `sv_regex()` rule function works properly", {
       ignore.case = TRUE
     )("The shinyvalidate package.")
   )
-  
+
   expect_null(
     sv_regex(
       pattern = "{shinyvalidate}",
@@ -456,7 +456,7 @@ test_that("the `sv_regex()` rule function works properly", {
 })
 
 test_that("the `sv_email()` rule function works properly", {
-  
+
   # Examples taken from: https://github.com/manishsaraan/email-validator
   always_pass <-
     c(
@@ -488,7 +488,7 @@ test_that("the `sv_email()` rule function works properly", {
       "com@sil.c1m",
       "t119037jskc_ihndkdoz@aakctgajathzffcsuqyjhgjuxnuulgnhxtnbquwtgxljfayeestsjdbalthtddy.lgtmsdhywswlameglunsaplsblljavswxrltovagexhtttodqedmicsekvpmpuu.pgjvdmvzyltpixvalfbktnnpjyjqswbfvtpbfsngqtmhgamhrbqqvyvlhqigggv.nxqglspfbwdhtfpibcrccvctmoxuxwlunghhwacjtrclgirrgppvshxvrzkoifl"
     )
-  
+
   always_fail <-
     c(
       "@missing-local.org",
@@ -523,30 +523,30 @@ test_that("the `sv_email()` rule function works properly", {
       ""
       # "tr119037jskc_ihndkdoz@d.aakctgajathzffcsuqyjhgjuxnuulgnhxtnbquwtgxljfayeestsjdbalthtddy.lgtmsdhywswlameglunsaplsblljavswxrltovagexhtttodqedmicsekvpmpuu.pgjvdmvzyltpixvalfbktnnpjyjqswbfvtpbfsngqtmhgamhrbqqvyvlhqigggv.nxqglspfbwdhtfpibcrccvctmoxuxwlunghhwacjtrclgirrgppvshxvrzkoifl"
     )
-  
+
   pass_if_multiple <- list(c("single-character-in-sld@x.org", "local@dash-in-sld.com"))
   pass_if_na <- list(NA_integer_)
   pass_if_multiple_na <- list(c("single-character-in-sld@x.org", NA))
-  
+
   rule <- sv_email()
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
-  
+
   rule <- sv_email(allow_multiple = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_na, !!!pass_if_multiple_na)
-  
+
   rule <- sv_email(allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_multiple_na)
-  
+
   rule <- sv_email(allow_multiple = TRUE, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
   expect_sv_fail(rule, !!!always_fail)
 })
 
 test_that("the `sv_url()` rule function works properly", {
-  
+
   always_pass <-
     c(
       "http://foo.com/blah_blah",
@@ -575,8 +575,8 @@ test_that("the `sv_url()` rule function works properly", {
       "http://a.b-c.de",
       "http://223.255.255.254"
     )
-  
-  always_fail <- 
+
+  always_fail <-
     c(
       "http://",
       "http://.",
@@ -610,49 +610,49 @@ test_that("the `sv_url()` rule function works properly", {
       "http://www.foo.bar./",
       "http://.www.foo.bar./"
     )
-  
+
   pass_if_multiple <- list(c("http://foo.com/blah_blah", "http://foo.com/blah_blah/"))
   pass_if_na <- list(NA_integer_)
   pass_if_multiple_na <- list(c("http://foo.com/blah_blah", NA))
-  
+
   rule <- sv_url()
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
-  
+
   rule <- sv_url(allow_multiple = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_na, !!!pass_if_multiple_na)
-  
+
   rule <- sv_url(allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!always_fail, !!!pass_if_multiple, !!!pass_if_multiple_na)
-  
+
   rule <- sv_url(allow_multiple = TRUE, allow_na = TRUE)
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
   expect_sv_fail(rule, !!!always_fail)
 })
 
 test_that("the `sv_required()` rule function works properly", {
-  
+
   always_pass <- list(3, "a", data.frame(a = 1:3))
 
   always_fail <- list("", rep("", 3), NULL, rep(NA, 3), character(0), numeric(0), logical(0))
-  
+
   rule <- sv_required()
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!always_fail)
 })
 
 test_that("the `sv_basic()` rule function works properly", {
-  
+
   always_pass <- list(-1, 0, 0L)
   pass_if_multiple <- list(c(-10:-1))
   pass_if_na <- list(NA, NA_integer_, NA_real_)
   pass_if_multiple_na <- list(c(-2, -1, NA), c(NA, NA, NA))
   pass_if_nan <- list(NaN)
   pass_if_inf <- list(-Inf)
-  
-  rule <- 
+
+  rule <-
     sv_basic(
       allow_multiple = FALSE,
       allow_na = FALSE,
@@ -661,7 +661,7 @@ test_that("the `sv_basic()` rule function works properly", {
     )
   expect_sv_pass(rule, !!!always_pass)
   expect_sv_fail(rule, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_inf, !!!pass_if_multiple_na)
-  
+
   rule <-
     sv_basic(
       allow_multiple = TRUE,
@@ -671,8 +671,8 @@ test_that("the `sv_basic()` rule function works properly", {
     )
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple)
   expect_sv_fail(rule, !!!pass_if_na, !!!pass_if_nan, !!!pass_if_inf, !!!pass_if_multiple_na)
-  
-  rule <- 
+
+  rule <-
     sv_basic(
       allow_multiple = FALSE,
       allow_na = TRUE,
@@ -681,8 +681,8 @@ test_that("the `sv_basic()` rule function works properly", {
     )
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_na)
   expect_sv_fail(rule, !!!pass_if_multiple, !!!pass_if_nan, !!!pass_if_inf, !!!pass_if_multiple_na)
-  
-  rule <- 
+
+  rule <-
     sv_basic(
       allow_multiple = FALSE,
       allow_na = FALSE,
@@ -691,8 +691,8 @@ test_that("the `sv_basic()` rule function works properly", {
     )
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_nan)
   expect_sv_fail(rule, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_inf, !!!pass_if_multiple_na)
-  
-  rule <- 
+
+  rule <-
     sv_basic(
       allow_multiple = TRUE,
       allow_na = TRUE,
@@ -701,8 +701,8 @@ test_that("the `sv_basic()` rule function works properly", {
     )
   expect_sv_pass(rule, !!!always_pass, !!!pass_if_multiple, !!!pass_if_na, !!!pass_if_multiple_na)
   expect_sv_fail(rule, !!!pass_if_nan, !!!pass_if_inf)
-  
-  rule <-     
+
+  rule <-
     sv_basic(
       allow_multiple = FALSE,
       allow_na = FALSE,
@@ -714,11 +714,11 @@ test_that("the `sv_basic()` rule function works properly", {
 })
 
 test_that("the `prepare_values_text()` prepares the text properly", {
-  
+
   expect_values_text <- function(set, limit, expected) {
     expect_equal(prepare_values_text(set = set, limit = limit), expected = expected)
   }
-  
+
   expect_values_text(set = 1:3, limit = 3, "1, 2, 3")
   expect_values_text(set = 1:2, limit = 3, "1, 2")
   expect_values_text(set = 1, limit = 3, "1")


### PR DESCRIPTION
Fixes https://github.com/rstudio/shinyvalidate/issues/34

Reprex:

```r
library(shiny)
library(shinyvalidate)

ui <- fluidPage(
  textInput("name", "Name")
)

server <- function(input, output, session) {

  # Create an InputValidator object
  iv <- InputValidator$new()

  # Add validation rules
  iv$add_rule("name", function(x) {
    if (!isTRUE(nzchar(x)) {
      htmltools::div(htmltools::code("name"), "is", htmltools::strong("not found"), "!")
    } else {
      NULL
    }
  })

  # Start displaying errors in the UI

  iv$enable()
}

shinyApp(ui, server)
```

![Screen Shot 2022-03-03 at 11 48 01 AM](https://user-images.githubusercontent.com/93231/156611485-cd59f2e3-1778-464b-b496-c988b52d2c9e.png)
