### PR TITLE
Check for NULL earlier in input_provided()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     htmltools (>= 0.5.1.1),
     rlang (>= 0.4.10),
     glue (>= 1.4.2)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Suggests:
     testthat,

--- a/R/rules.R
+++ b/R/rules.R
@@ -271,6 +271,8 @@ sv_regex <- function(pattern,
 #' @param message The validation error message to use if a value doesn't match a
 #'   regex pattern for email address detection.
 #' @inheritParams sv_numeric
+#' @param allow_na If `FALSE`, then any `NA` element will cause validation to 
+#'   fail.
 #'
 #' @return A function suitable for use as an
 #'   [`InputValidator$add_rule()`][InputValidator] rule.
@@ -353,7 +355,7 @@ sv_email <- function(message = "Not a valid email address",
 #'
 #' @param message The validation error message to use if a value doesn't match a
 #'   regex pattern for URL detection.
-#' @inheritParams sv_numeric
+#' @inheritParams sv_email
 #'
 #' @return A function suitable for use as an
 #'   [`InputValidator$add_rule()`][InputValidator] rule.

--- a/R/validator.R
+++ b/R/validator.R
@@ -443,14 +443,12 @@ input_provided <- function(val) {
   # * FALSE (or a logical vector containing only FALSEs) is not truthy, but it
   #   is provided.
   
-  if (inherits(val, 'try-error'))
-    return(FALSE)
-  
-  if (!is.atomic(val))
-    return(TRUE)
-  
   if (is.null(val))
     return(FALSE)
+  if (inherits(val, 'try-error'))
+    return(FALSE)
+  if (!is.atomic(val))
+    return(TRUE)
   if (length(val) == 0)
     return(FALSE)
   if (all(is.na(val)))

--- a/man/InputValidator.Rd
+++ b/man/InputValidator.Rd
@@ -32,22 +32,22 @@ that are completely unrelated to each other; each form would have its own
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{InputValidator$new()}}
-\item \href{#method-parent}{\code{InputValidator$parent()}}
-\item \href{#method-condition}{\code{InputValidator$condition()}}
-\item \href{#method-add_validator}{\code{InputValidator$add_validator()}}
-\item \href{#method-add_rule}{\code{InputValidator$add_rule()}}
-\item \href{#method-enable}{\code{InputValidator$enable()}}
-\item \href{#method-disable}{\code{InputValidator$disable()}}
-\item \href{#method-fields}{\code{InputValidator$fields()}}
-\item \href{#method-is_valid}{\code{InputValidator$is_valid()}}
-\item \href{#method-validate}{\code{InputValidator$validate()}}
-\item \href{#method-_validate_impl}{\code{InputValidator$_validate_impl()}}
+\item \href{#method-InputValidator-new}{\code{InputValidator$new()}}
+\item \href{#method-InputValidator-parent}{\code{InputValidator$parent()}}
+\item \href{#method-InputValidator-condition}{\code{InputValidator$condition()}}
+\item \href{#method-InputValidator-add_validator}{\code{InputValidator$add_validator()}}
+\item \href{#method-InputValidator-add_rule}{\code{InputValidator$add_rule()}}
+\item \href{#method-InputValidator-enable}{\code{InputValidator$enable()}}
+\item \href{#method-InputValidator-disable}{\code{InputValidator$disable()}}
+\item \href{#method-InputValidator-fields}{\code{InputValidator$fields()}}
+\item \href{#method-InputValidator-is_valid}{\code{InputValidator$is_valid()}}
+\item \href{#method-InputValidator-validate}{\code{InputValidator$validate()}}
+\item \href{#method-InputValidator-_validate_impl}{\code{InputValidator$_validate_impl()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-InputValidator-new"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new validator object.
 \subsection{Usage}{
@@ -73,8 +73,8 @@ the default.)}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-parent"></a>}}
-\if{latex}{\out{\hypertarget{method-parent}{}}}
+\if{html}{\out{<a id="method-InputValidator-parent"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-parent}{}}}
 \subsection{Method \code{parent()}}{
 For internal use only.
 \subsection{Usage}{
@@ -90,8 +90,8 @@ For internal use only.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-condition"></a>}}
-\if{latex}{\out{\hypertarget{method-condition}{}}}
+\if{html}{\out{<a id="method-InputValidator-condition"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-condition}{}}}
 \subsection{Method \code{condition()}}{
 Gets or sets a condition that overrides all of the rules in
 this validator. Before performing validation, this validator will
@@ -120,8 +120,8 @@ returned.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_validator"></a>}}
-\if{latex}{\out{\hypertarget{method-add_validator}{}}}
+\if{html}{\out{<a id="method-InputValidator-add_validator"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-add_validator}{}}}
 \subsection{Method \code{add_validator()}}{
 Add another \code{InputValidator} object to this one, as a
 "child". Any time this validator object is asked for its validity, it
@@ -148,8 +148,8 @@ default, a label will be automatically generated.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_rule"></a>}}
-\if{latex}{\out{\hypertarget{method-add_rule}{}}}
+\if{html}{\out{<a id="method-InputValidator-add_rule"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-add_rule}{}}}
 \subsection{Method \code{add_rule()}}{
 Add an input validation rule. Each input validation rule
 applies to a single input. You can add multiple validation rules for a
@@ -190,8 +190,8 @@ almost never a reason to change this from the default.)}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-enable"></a>}}
-\if{latex}{\out{\hypertarget{method-enable}{}}}
+\if{html}{\out{<a id="method-InputValidator-enable"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-enable}{}}}
 \subsection{Method \code{enable()}}{
 Begin displaying input validation feedback in the user
 interface. Once enabled, this validator object will automatically keep
@@ -205,8 +205,8 @@ calls to \code{enable()} on this validator will be ignored.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-disable"></a>}}
-\if{latex}{\out{\hypertarget{method-disable}{}}}
+\if{html}{\out{<a id="method-InputValidator-disable"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-disable}{}}}
 \subsection{Method \code{disable()}}{
 Clear existing input validation feedback in the user
 interface for all inputs represented in this validator's ruleset, and
@@ -218,8 +218,8 @@ called to resume input validation.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-fields"></a>}}
-\if{latex}{\out{\hypertarget{method-fields}{}}}
+\if{html}{\out{<a id="method-InputValidator-fields"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-fields}{}}}
 \subsection{Method \code{fields()}}{
 Returns \code{TRUE} if all input validation rules currently pass,
 \code{FALSE} if not.
@@ -229,8 +229,8 @@ Returns \code{TRUE} if all input validation rules currently pass,
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-is_valid"></a>}}
-\if{latex}{\out{\hypertarget{method-is_valid}{}}}
+\if{html}{\out{<a id="method-InputValidator-is_valid"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-is_valid}{}}}
 \subsection{Method \code{is_valid()}}{
 Returns \code{TRUE} if all input validation rules currently pass,
 \code{FALSE} if not.
@@ -240,8 +240,8 @@ Returns \code{TRUE} if all input validation rules currently pass,
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-validate"></a>}}
-\if{latex}{\out{\hypertarget{method-validate}{}}}
+\if{html}{\out{<a id="method-InputValidator-validate"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-validate}{}}}
 \subsection{Method \code{validate()}}{
 Run validation rules and gather results. For advanced usage
 only; most apps should use the \code{is_valid()} and \code{enable()} methods
@@ -255,8 +255,8 @@ character vector describing a validation problem.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-_validate_impl"></a>}}
-\if{latex}{\out{\hypertarget{method-_validate_impl}{}}}
+\if{html}{\out{<a id="method-InputValidator-_validate_impl"></a>}}
+\if{latex}{\out{\hypertarget{method-InputValidator-_validate_impl}{}}}
 \subsection{Method \code{_validate_impl()}}{
 For internal use only.
 \subsection{Usage}{

--- a/man/sv_between.Rd
+++ b/man/sv_between.Rd
@@ -28,10 +28,7 @@ match the rule. The message can be customized by using the \code{"{left}"} and
 and \code{right} values. While the default message uses both of these string
 parameters, they are not required in a user-defined \code{message_fmt} string.}
 
-\item{allow_na}{If \code{FALSE} (the default for both options), then any
-\code{NA} or \code{NaN} element will cause validation to fail.}
-
-\item{allow_nan}{If \code{FALSE} (the default for both options), then any
+\item{allow_na, allow_nan}{If \code{FALSE} (the default for both options), then any
 \code{NA} or \code{NaN} element will cause validation to fail.}
 }
 \value{

--- a/man/sv_email.Rd
+++ b/man/sv_email.Rd
@@ -18,6 +18,9 @@ regex pattern for email address detection.}
 vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
+
+\item{allow_na}{If \code{FALSE}, then any \code{NA} element will cause validation to
+fail.}
 }
 \value{
 A function suitable for use as an

--- a/man/sv_email.Rd
+++ b/man/sv_email.Rd
@@ -18,9 +18,6 @@ regex pattern for email address detection.}
 vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
-
-\item{allow_na}{If \code{FALSE} (the default for both options), then any
-\code{NA} or \code{NaN} element will cause validation to fail.}
 }
 \value{
 A function suitable for use as an

--- a/man/sv_equal.Rd
+++ b/man/sv_equal.Rd
@@ -29,10 +29,7 @@ vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
 
-\item{allow_na}{If \code{FALSE} (the default for both options), then any
-\code{NA} or \code{NaN} element will cause validation to fail.}
-
-\item{allow_nan}{If \code{FALSE} (the default for both options), then any
+\item{allow_na, allow_nan}{If \code{FALSE} (the default for both options), then any
 \code{NA} or \code{NaN} element will cause validation to fail.}
 
 \item{allow_inf}{If \code{FALSE} (the default), then any \code{Inf} or \code{-Inf} element

--- a/man/sv_gt.Rd
+++ b/man/sv_gt.Rd
@@ -29,10 +29,7 @@ vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
 
-\item{allow_na}{If \code{FALSE} (the default for both options), then any
-\code{NA} or \code{NaN} element will cause validation to fail.}
-
-\item{allow_nan}{If \code{FALSE} (the default for both options), then any
+\item{allow_na, allow_nan}{If \code{FALSE} (the default for both options), then any
 \code{NA} or \code{NaN} element will cause validation to fail.}
 
 \item{allow_inf}{If \code{FALSE} (the default), then any \code{Inf} or \code{-Inf} element

--- a/man/sv_gte.Rd
+++ b/man/sv_gte.Rd
@@ -29,10 +29,7 @@ vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
 
-\item{allow_na}{If \code{FALSE} (the default for both options), then any
-\code{NA} or \code{NaN} element will cause validation to fail.}
-
-\item{allow_nan}{If \code{FALSE} (the default for both options), then any
+\item{allow_na, allow_nan}{If \code{FALSE} (the default for both options), then any
 \code{NA} or \code{NaN} element will cause validation to fail.}
 
 \item{allow_inf}{If \code{FALSE} (the default), then any \code{Inf} or \code{-Inf} element

--- a/man/sv_integer.Rd
+++ b/man/sv_integer.Rd
@@ -20,10 +20,7 @@ vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
 
-\item{allow_na}{If \code{FALSE} (the default for both options), then any
-\code{NA} or \code{NaN} element will cause validation to fail.}
-
-\item{allow_nan}{If \code{FALSE} (the default for both options), then any
+\item{allow_na, allow_nan}{If \code{FALSE} (the default for both options), then any
 \code{NA} or \code{NaN} element will cause validation to fail.}
 }
 \value{

--- a/man/sv_lt.Rd
+++ b/man/sv_lt.Rd
@@ -29,10 +29,7 @@ vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
 
-\item{allow_na}{If \code{FALSE} (the default for both options), then any
-\code{NA} or \code{NaN} element will cause validation to fail.}
-
-\item{allow_nan}{If \code{FALSE} (the default for both options), then any
+\item{allow_na, allow_nan}{If \code{FALSE} (the default for both options), then any
 \code{NA} or \code{NaN} element will cause validation to fail.}
 
 \item{allow_inf}{If \code{FALSE} (the default), then any \code{Inf} or \code{-Inf} element

--- a/man/sv_lte.Rd
+++ b/man/sv_lte.Rd
@@ -29,10 +29,7 @@ vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
 
-\item{allow_na}{If \code{FALSE} (the default for both options), then any
-\code{NA} or \code{NaN} element will cause validation to fail.}
-
-\item{allow_nan}{If \code{FALSE} (the default for both options), then any
+\item{allow_na, allow_nan}{If \code{FALSE} (the default for both options), then any
 \code{NA} or \code{NaN} element will cause validation to fail.}
 
 \item{allow_inf}{If \code{FALSE} (the default), then any \code{Inf} or \code{-Inf} element

--- a/man/sv_not_equal.Rd
+++ b/man/sv_not_equal.Rd
@@ -29,10 +29,7 @@ vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
 
-\item{allow_na}{If \code{FALSE} (the default for both options), then any
-\code{NA} or \code{NaN} element will cause validation to fail.}
-
-\item{allow_nan}{If \code{FALSE} (the default for both options), then any
+\item{allow_na, allow_nan}{If \code{FALSE} (the default for both options), then any
 \code{NA} or \code{NaN} element will cause validation to fail.}
 
 \item{allow_inf}{If \code{FALSE} (the default), then any \code{Inf} or \code{-Inf} element

--- a/man/sv_url.Rd
+++ b/man/sv_url.Rd
@@ -14,9 +14,6 @@ regex pattern for URL detection.}
 vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
-
-\item{allow_na}{If \code{FALSE} (the default for both options), then any
-\code{NA} or \code{NaN} element will cause validation to fail.}
 }
 \value{
 A function suitable for use as an

--- a/man/sv_url.Rd
+++ b/man/sv_url.Rd
@@ -14,6 +14,9 @@ regex pattern for URL detection.}
 vector must be exactly one; if \code{TRUE}, then any length is allowed
 (including a length of zero; use \code{\link[=sv_required]{sv_required()}} if one or more values
 should be required).}
+
+\item{allow_na}{If \code{FALSE}, then any \code{NA} element will cause validation to
+fail.}
 }
 \value{
 A function suitable for use as an

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -23,6 +23,10 @@ test_that("InputValidator cannot be constructed without a session", {
 })
 
 test_that("InputValidator add_rule()", {
+  if (packageVersion("shiny") <= "1.7.5" && getRversion() > "4.3.1") {
+    skip("Skipping InputValidator add_rule() tests since shiny::need doesn't work as intended.")
+  }
+  
   session <- shiny::MockShinySession$new()
   shiny::withReactiveDomain(session, {
     iv <- InputValidator$new()


### PR DESCRIPTION
Closes #73 

Note that this PR is basically the same as https://github.com/rstudio/shiny/pull/3908, which makes a similar change to `isTruthy()` (it's implementation is basically copied here in `shinyvalidate::input_provided()`)

PS., @rich-iannone, let me know if you'd like to hand over maintainer-ship of `{shinyvalidate}` (either way, I can put together a submission for you) 